### PR TITLE
move editor camera to baselevelcamera. improve drag option for basele…

### DIFF
--- a/scenes/BaseLevelCamera.gd
+++ b/scenes/BaseLevelCamera.gd
@@ -1,34 +1,34 @@
 extends Camera2D
 
-var fixed_toggle_point:Vector2 = Vector2()
+
+var drag_offset = Vector2()
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	pass # Replace with function body.
 
+
 func _process(delta):
-	 # This happens once 'camera_drag' is pressed
-	if Input.is_action_just_pressed('camera_drag'):
-		var ref = get_viewport().get_mouse_position()
-		fixed_toggle_point = ref
-	# This happens while 'camera_drag' is pressed
-	if Input.is_action_pressed('camera_drag'):
-		drag_camera()
+	var move_offset = drag_offset * delta * 10
+	drag_offset -= move_offset
+	position += move_offset
+
 
 # handle input that wasn't catcher by ui etc.
 func _unhandled_input(event):
 	if Input.is_action_just_pressed("zoom_in"):
 		var position = (event as InputEventMouseButton).position
 		zoom_at_point(0.9, position)
+	
 	if Input.is_action_just_pressed("zoom_out"):
 		var position = (event as InputEventMouseButton).position
 		zoom_at_point(1.1, position)
+	
+	if Input.is_action_pressed("camera_drag") and event is InputEventMouseMotion:
+		var relative = (event as InputEventMouseMotion).relative
+		drag_offset -= relative * zoom
 
-# drags the camera around
-func drag_camera():
-	var ref = get_viewport().get_mouse_position()
-	global_position.x += -(ref.x - fixed_toggle_point.x) / 10
-	global_position.y += -(ref.y - fixed_toggle_point.y) / 10
 
 # zoom in/out with the center at a certain point (e.g. mouse position)
 func zoom_at_point(zoom_change, point):

--- a/scenes/MoonCamera.gd
+++ b/scenes/MoonCamera.gd
@@ -1,4 +1,6 @@
-extends Camera2D
+extends "res://scenes/BaseLevelCamera.gd"
+
+signal target_reached
 
 
 export var max_offset : float = 80.0
@@ -32,6 +34,8 @@ func _process(delta):
 	# follow target
 	if target != null:
 		position = position.linear_interpolate(target.position, delta * 5)
+		if (target.position - position).length() < 0.1:
+			emit_signal("target_reached")
 		
 	# apply screen shake
 	_process_shake(global_transform.origin, 0.0, delta)

--- a/scenes/PlayableLevel.gd
+++ b/scenes/PlayableLevel.gd
@@ -99,4 +99,10 @@ func _on_BlackHole_body_exited(body):
 
 
 func _on_Moon_exploded():
+	camera.target = null
 	emit_signal("failure")
+
+
+func _on_Camera2D_target_reached():
+	if camera.target != moon:
+		camera.target = null

--- a/scenes/PlayableLevel.tscn
+++ b/scenes/PlayableLevel.tscn
@@ -150,4 +150,5 @@ anims/setup = SubResource( 4 )
 [connection signal="stationary" from="Moon" to="." method="_on_Moon_stationary"]
 [connection signal="body_entered" from="BlackHole" to="." method="_on_BlackHole_body_entered"]
 [connection signal="body_exited" from="BlackHole" to="." method="_on_BlackHole_body_exited"]
+[connection signal="target_reached" from="Camera2D" to="." method="_on_Camera2D_target_reached"]
 [connection signal="pressed" from="Fortuna/CanvasLayer/MarginContainer/Portrait" to="Fortuna" method="_on_Portrait_pressed"]

--- a/scenes/level_editor/LevelEditor.tscn
+++ b/scenes/level_editor/LevelEditor.tscn
@@ -2,10 +2,12 @@
 
 [ext_resource path="res://scenes/level_editor/LevelEditor.gd" type="Script" id=1]
 [ext_resource path="res://scenes/BaseLevel.tscn" type="PackedScene" id=2]
-[ext_resource path="res://scenes/level_editor/EditorCamera.gd" type="Script" id=3]
+[ext_resource path="res://scenes/BaseLevelCamera.gd" type="Script" id=3]
 [ext_resource path="res://scenes/EditableLevel.gd" type="Script" id=4]
 [ext_resource path="res://scenes/level_editor/ArrowLeft.svg" type="Texture" id=5]
 [ext_resource path="res://resources/default_theme.tres" type="Theme" id=6]
+
+
 
 [sub_resource type="InputEventAction" id=1]
 action = "ui_cancel"

--- a/scenes/objects/AsteroidSpawner.gd
+++ b/scenes/objects/AsteroidSpawner.gd
@@ -15,8 +15,6 @@ func _ready():
 		_draw()
 	else:
 		$Line2D.visible = false
-	_load_asteroid()
-	pass # Replace with function body.
 
 func _draw():
 	if SceneLoader.current_scene.name == "LevelEditor":


### PR DESCRIPTION
…velcamera. make moon camera inherit from baselevelcamera, so that it can be dragged and zoomed. disable loading an asteriod in the moment the asteroid spawner es generated (this might improve lags, when levels are loaded)